### PR TITLE
Install snappy package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ WORKDIR /app
 COPY --from=build-env /app/out .
 
 RUN apt-get update && \
-    apt-get install -y --allow-unauthenticated libc6-dev jq curl && \
+    apt-get install -y --allow-unauthenticated libc6-dev libsnappy-dev jq curl && \
     rm -rf /var/lib/apt/lists/*
 
 VOLUME /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,12 +32,11 @@ EOF
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0
 WORKDIR /app
-RUN apt-get update && apt-get install -y libc6-dev
 COPY --from=build-env /app/out .
 
 RUN apt-get update && \
     apt-get install -y --allow-unauthenticated libc6-dev jq curl && \
-    rm -rf /var/lib/apt/lists/* 
+    rm -rf /var/lib/apt/lists/*
 
 VOLUME /data
 


### PR DESCRIPTION
When I run `sudo docker run planetariumhq/emptychronicle:git-daadeae8691394f038237ee619b58351fdef9bdb --heimdall`, it fails with `Unhandled Exception: System.TypeInitializationException: The type initializer for 'RocksDbSharp.Native' threw an exception.`. After installing `libsnappy-dev` package, it works well.