### PR TITLE
Do Bootstrap before Preload

### DIFF
--- a/EmptyChronicle/Hosting/SwarmService.cs
+++ b/EmptyChronicle/Hosting/SwarmService.cs
@@ -23,6 +23,11 @@ public class SwarmService : BackgroundService
         }, stoppingToken);
 
         await _swarm.AddPeersAsync(_peers, default, cancellationToken: stoppingToken).ConfigureAwait(false);
+        await _swarm.BootstrapAsync(
+            seedPeers: _peers,
+            searchDepth: 1,
+            dialTimeout: null,
+            cancellationToken: stoppingToken).ConfigureAwait(false);
         await _swarm.PreloadAsync(cancellationToken: stoppingToken).ConfigureAwait(false);
         await _swarm.StartAsync(cancellationToken: stoppingToken).ConfigureAwait(false);
     }


### PR DESCRIPTION
EmptyChronicle often hangs because there are no peers to communicate with. I guess it is because it isn't bootstrapped.